### PR TITLE
Fix problem with external redirects

### DIFF
--- a/Controller/WebsiteRedirectController.php
+++ b/Controller/WebsiteRedirectController.php
@@ -31,13 +31,15 @@ class WebsiteRedirectController
     public function redirect(Request $request, RedirectRouteInterface $redirectRoute)
     {
         $queryString = http_build_query($request->query->all());
+
         $url = [
-            $request->getSchemeAndHttpHost(),
             $redirectRoute->getTarget(),
-            (!empty($queryString) ? '?' : ''),
+            strpos($redirectRoute->getTarget(), '?') === false ? '?' : '&',
             $queryString,
         ];
 
-        return new RedirectResponse(implode($url), $redirectRoute->getStatusCode());
+        $url = trim(implode($url), '&? ');
+
+        return new RedirectResponse($url, $redirectRoute->getStatusCode());
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Use the target without prefixing it with schema and host.

#### Why?

Allow redirect to external resources.

#### Example Usage

/test -> http://other-domain.de/test