### PR TITLE
Added rawurldecode to decode path-info before searching for route

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
   - composer self-update
 
 install:
+  - phpenv config-add Tests/travis.php.ini
   - travis_retry composer update $COMPOSER_FLAGS
   - composer info -i
   - ./Tests/app/console doctrine:database:create

--- a/Routing/RedirectRouteProvider.php
+++ b/Routing/RedirectRouteProvider.php
@@ -40,13 +40,17 @@ class RedirectRouteProvider implements RouteProviderInterface
      */
     public function getRouteCollectionForRequest(Request $request)
     {
+        // server encodes the url and symfony does not encode it
+        // symfony decodes this data here https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L91
+        $pathInfo = rawurldecode($request->getPathInfo());
+
         $routeCollection = new RouteCollection();
-        if (!$redirectRoute = $this->redirectRouteRepository->findEnabledBySource($request->getPathInfo())) {
+        if (!$redirectRoute = $this->redirectRouteRepository->findEnabledBySource($pathInfo)) {
             return $routeCollection;
         }
 
         $route = new Route(
-            $request->getPathInfo(),
+            $redirectRoute->getSource(),
             [
                 '_controller' => 'sulu_redirect.controller.redirect:redirect',
                 'redirectRoute' => $redirectRoute,

--- a/Tests/Unit/Routing/RedirectRouteProviderTest.php
+++ b/Tests/Unit/Routing/RedirectRouteProviderTest.php
@@ -52,6 +52,31 @@ class RedirectRouteProviderTest extends \PHPUnit_Framework_TestCase
 
         $redirectRoute = $this->prophesize(RedirectRouteInterface::class);
         $redirectRoute->getId()->willReturn($uuid);
+        $redirectRoute->getSource()->willReturn($pathInfo);
+        $this->repository->findEnabledBySource($pathInfo)->willReturn($redirectRoute->reveal());
+
+        $result = $this->routeProvider->getRouteCollectionForRequest($this->request->reveal());
+        $this->assertCount(1, $result);
+
+        $this->assertEquals(
+            [
+                '_controller' => 'sulu_redirect.controller.redirect:redirect',
+                'redirectRoute' => $redirectRoute->reveal(),
+            ],
+            $result->get('sulu_redirect.' . $uuid)->getDefaults()
+        );
+    }
+
+    public function testGetRouteCollectionForRequestEncodedPathInfo()
+    {
+        $pathInfo = '/käße';
+        $uuid = '123-123-123';
+
+        $this->request->getPathInfo()->willReturn(rawurlencode($pathInfo));
+
+        $redirectRoute = $this->prophesize(RedirectRouteInterface::class);
+        $redirectRoute->getId()->willReturn($uuid);
+        $redirectRoute->getSource()->willReturn($pathInfo);
         $this->repository->findEnabledBySource($pathInfo)->willReturn($redirectRoute->reveal());
 
         $result = $this->routeProvider->getRouteCollectionForRequest($this->request->reveal());

--- a/Tests/travis.php.ini
+++ b/Tests/travis.php.ini
@@ -1,0 +1,1 @@
+memory_limit = 2048M


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixes an issue with umlauts in the source. The server encodes the URL and Symfony returns this in `getPathInfo`. We use this to find the redirect-route. This leads into a not found route.