### PR TITLE
Added detect linebreak and improve duplicate detection

### DIFF
--- a/Import/Reader/CsvReader.php
+++ b/Import/Reader/CsvReader.php
@@ -23,6 +23,8 @@ class CsvReader implements ReaderInterface
      */
     public function read($fileName)
     {
+        ini_set('auto_detect_line_endings', true); // For mac's office excel csv
+
         $csv = new SplFileObject($fileName);
         $csv->setCsvControl();
         $csv->setFlags(SplFileObject::READ_CSV);

--- a/Import/Reader/ReaderItem.php
+++ b/Import/Reader/ReaderItem.php
@@ -24,7 +24,7 @@ class ReaderItem
     /**
      * @var string
      */
-    private $content;
+    private $lineContent;
 
     /**
      * @var array
@@ -36,18 +36,12 @@ class ReaderItem
      */
     private $exception;
 
-    /**
-     * @param int $lineNumber
-     * @param string $lineContent
-     * @param array $item
-     * @param \Exception $exception
-     */
-    public function __construct($lineNumber, $lineContent, array $item = null, \Exception $exception = null)
+    public function __construct($lineNumber, $lineContent, array $data = null, \Exception $exception = null)
     {
         $this->lineNumber = $lineNumber;
-        $this->data = $item;
-        $this->exception = $exception;
         $this->lineContent = $lineContent;
+        $this->data = $data;
+        $this->exception = $exception;
     }
 
     /**

--- a/Import/Writer/Writer.php
+++ b/Import/Writer/Writer.php
@@ -57,7 +57,7 @@ class Writer implements WriterInterface
     public function write(RedirectRouteInterface $entity)
     {
         $this->validate($entity);
-        $this->sources[] = $entity->getSource();
+        $this->sources[] = strtolower($entity->getSource());
 
         try {
             $this->save($entity);
@@ -116,7 +116,7 @@ class Writer implements WriterInterface
             throw new TargetIsEmptyException($entity);
         }
 
-        if (in_array($entity->getSource(), $this->sources)) {
+        if (in_array(strtolower($entity->getSource()), $this->sources)) {
             throw new DuplicatedSourceException($entity);
         }
     }

--- a/Tests/Unit/Import/Writer/WriterTest.php
+++ b/Tests/Unit/Import/Writer/WriterTest.php
@@ -117,6 +117,28 @@ class WriterTest extends \PHPUnit_Framework_TestCase
         $this->redirectRouteManager->save($entities[1]->reveal())->shouldNotBeCalled();
     }
 
+    public function testWriteDuplicatedCaseInSensitive()
+    {
+        $this->setExpectedException(DuplicatedSourceException::class);
+
+        $entities = [
+            $this->prophesize(RedirectRouteInterface::class),
+            $this->prophesize(RedirectRouteInterface::class),
+        ];
+
+        $entities[0]->getSource()->willReturn('/source');
+        $entities[0]->getTarget()->willReturn('/target');
+
+        $entities[1]->getSource()->willReturn('/Source');
+        $entities[1]->getTarget()->willReturn('/target');
+
+        $this->writer->write($entities[0]->reveal());
+        $this->writer->write($entities[1]->reveal());
+
+        $this->redirectRouteManager->save($entities[0]->reveal())->shouldBeCalled();
+        $this->redirectRouteManager->save($entities[1]->reveal())->shouldNotBeCalled();
+    }
+
     public function testWriteAlreadyExisting()
     {
         $this->setExpectedException(DuplicatedSourceException::class);


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR adds the detection of linebreak to allow `\r\n` or `\n`. Additionally, it improves the detection of duplicated entries (case-insensitive).

#### Why?

Files from mac excel are not supported currently.