### PR TITLE
Fixed get resource-segment by locale

### DIFF
--- a/GoneSubscriber/GoneDocumentSubscriber.php
+++ b/GoneSubscriber/GoneDocumentSubscriber.php
@@ -134,10 +134,16 @@ class GoneDocumentSubscriber implements EventSubscriberInterface
             return $urls;
         }
 
+        $localizedUrls = $this->documentInspector->getLocalizedUrlsForPage($document);
+
         foreach ($webspace->getAllLocalizations() as $localization) {
+            if (!array_key_exists($localization->getLocale(), $localizedUrls)) {
+                continue;
+            }
+
             $urls = array_merge(
                 $this->webspaceManager->findUrlsByResourceLocator(
-                    $document->getResourceSegment(),
+                    $localizedUrls[$localization->getLocale()],
                     $this->environment,
                     $localization->getLocale()
                 ),

--- a/Tests/Unit/GoneSubscriber/GoneDocumentSubscriberTest.php
+++ b/Tests/Unit/GoneSubscriber/GoneDocumentSubscriberTest.php
@@ -82,14 +82,15 @@ class GoneDocumentSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $this->document = $this->prophesize(BasePageDocument::class);
         $this->document->getUuid()->willReturn('123-123-123');
-        $this->document->getResourceSegment()->willReturn('/abc');
 
         $this->entityManager = $this->prophesize(EntityManager::class);
 
         $this->redirectRouteManager = $this->prophesize(RedirectRouteManager::class);
 
         $this->documentInspector = $this->prophesize(DocumentInspector::class);
-        $this->documentInspector->getWebspace($this->document)->willReturn('example');
+        $this->documentInspector->getWebspace($this->document->reveal())->willReturn('example');
+
+        $this->documentInspector->getLocalizedUrlsForPage($this->document->reveal())->willReturn(['de' => '/artikel', 'en' => '/article']);
 
         $this->webspace = $this->prophesize(Webspace::class);
         $this->webspace->getAllLocalizations()->willReturn([
@@ -99,25 +100,21 @@ class GoneDocumentSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $this->webspaceManager = $this->prophesize(WebspaceManager::class);
         $this->webspaceManager->findWebspaceByKey('example')->willReturn($this->webspace->reveal());
-        $this->webspaceManager->findUrlsByResourceLocator('/abc', 'test', 'en')
-            ->willReturn(['http://{host}/en/abc']);
-        $this->webspaceManager->findUrlsByResourceLocator('/abc1', 'test', 'en')
-            ->willReturn(['http://{host}/en/abc1']);
-        $this->webspaceManager->findUrlsByResourceLocator('/abc2', 'test', 'en')
-            ->willReturn(['http://{host}/en/abc2']);
-        $this->webspaceManager->findUrlsByResourceLocator('/abc', 'test', 'de')
-            ->willReturn(['http://{host}/en/abc']);
-        $this->webspaceManager->findUrlsByResourceLocator('/abc1', 'test', 'de')
-            ->willReturn(['http://{host}/en/abc1']);
-        $this->webspaceManager->findUrlsByResourceLocator('/abc2', 'test', 'de')
-            ->willReturn(['http://{host}/en/abc2']);
+        $this->webspaceManager->findUrlsByResourceLocator('/article', 'test', 'en')
+            ->willReturn(['http://{host}/en/article']);
+        $this->webspaceManager->findUrlsByResourceLocator('/article1', 'test', 'en')
+            ->willReturn(['http://{host}/en/article1']);
+        $this->webspaceManager->findUrlsByResourceLocator('/article2', 'test', 'en')
+            ->willReturn(['http://{host}/en/article2']);
+        $this->webspaceManager->findUrlsByResourceLocator('/artikel', 'test', 'de')
+            ->willReturn(['http://{host}/de/artikel']);
 
         $this->resourceLocatorStrategy = $this->prophesize(ResourceLocatorStrategyInterface::class);
         $this->resourceLocatorStrategy->loadHistoryByContentUuid('123-123-123', 'example', 'en')
             ->willReturn(
                 [
-                    new ResourceLocatorInformation('/abc1', new \DateTime(), '1'),
-                    new ResourceLocatorInformation('/abc2', new \DateTime(), '1'),
+                    new ResourceLocatorInformation('/article1', new \DateTime(), '1'),
+                    new ResourceLocatorInformation('/article2', new \DateTime(), '1'),
                 ]
             );
         $this->resourceLocatorStrategy->loadHistoryByContentUuid('123-123-123', 'example', 'de')

--- a/Tests/app/config/config.yml
+++ b/Tests/app/config/config.yml
@@ -1,4 +1,5 @@
 # Doctrine Configuration
 doctrine:
     dbal:
+        host: 127.0.0.1
         dbname: "su_redirect_test"


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

Fixed gone-subscriber to retrieve correct resource-segment per locale.