### PR TITLE
Fixed memory_limit for travis tests

### DIFF
--- a/Tests/travis.php.ini
+++ b/Tests/travis.php.ini
@@ -1,1 +1,1 @@
-memory_limit = 2048M
+memory_limit = 4096M


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixed the memory_limit for travis tests.