### PR TITLE
Added check for enabled gone subscriber

### DIFF
--- a/DependencyInjection/SuluRedirectExtension.php
+++ b/DependencyInjection/SuluRedirectExtension.php
@@ -78,6 +78,9 @@ class SuluRedirectExtension extends Extension implements PrependExtensionInterfa
         $loader->load('services.xml');
         $loader->load('router.xml');
         $loader->load('import.xml');
-        $loader->load('gone_subscriber.xml');
+
+        if ($config['gone_on_remove']['enabled']) {
+            $loader->load('gone_subscriber.xml');
+        }
     }
 }

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -49,6 +49,10 @@ php bin/console doctrine:schema:update
 
 ```yml
 sulu_redirect:
+
+    # When enabled, this feature automatically creates redirects with http status code 410 when a document with route or an route entity is removed.
+    gone_on_remove:
+        enabled:              true
     imports:
         path:                 '%kernel.root_dir%/../var/uploads/redirects'
     objects:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #29 
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR fixes the extension to allow disable the gone_subscriber