### PR TITLE
Fixed 410 empty target in import

### DIFF
--- a/Import/Writer/Writer.php
+++ b/Import/Writer/Writer.php
@@ -15,6 +15,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\RedirectBundle\Manager\RedirectRouteManagerInterface;
 use Sulu\Bundle\RedirectBundle\Manager\RedirectRouteNotUniqueException;
 use Sulu\Bundle\RedirectBundle\Model\RedirectRouteInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Write redirect-route entity to database by using the entity-manager.
@@ -112,7 +113,7 @@ class Writer implements WriterInterface
      */
     private function validate(RedirectRouteInterface $entity)
     {
-        if ('' === $entity->getTarget()) {
+        if ('' === $entity->getTarget() && Response::HTTP_GONE !== $entity->getStatusCode()) {
             throw new TargetIsEmptyException($entity);
         }
 

--- a/Tests/Unit/Import/Writer/WriterTest.php
+++ b/Tests/Unit/Import/Writer/WriterTest.php
@@ -13,10 +13,12 @@ namespace Sulu\Bundle\RedirectBundle\Tests\Unit\Import\Writer;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Sulu\Bundle\RedirectBundle\Import\Writer\DuplicatedSourceException;
+use Sulu\Bundle\RedirectBundle\Import\Writer\TargetIsEmptyException;
 use Sulu\Bundle\RedirectBundle\Import\Writer\Writer;
 use Sulu\Bundle\RedirectBundle\Manager\RedirectRouteManagerInterface;
 use Sulu\Bundle\RedirectBundle\Manager\RedirectRouteNotUniqueException;
 use Sulu\Bundle\RedirectBundle\Model\RedirectRouteInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 class WriterTest extends \PHPUnit_Framework_TestCase
 {
@@ -152,6 +154,34 @@ class WriterTest extends \PHPUnit_Framework_TestCase
             ->willThrow($this->prophesize(RedirectRouteNotUniqueException::class)->reveal());
 
         $this->writer->write($entity->reveal());
+    }
+
+    public function testWriteEmptyTarget()
+    {
+        $this->setExpectedException(TargetIsEmptyException::class);
+
+        $entity = $this->prophesize(RedirectRouteInterface::class);
+        $entity->getSource()->willReturn('/source');
+        $entity->getTarget()->willReturn('');
+        $entity->getStatusCode()->willReturn(Response::HTTP_MOVED_PERMANENTLY);
+
+        $this->redirectRouteManager->save($entity->reveal())->shouldNotBeCalled();
+
+        $this->writer->write($entity->reveal());
+    }
+
+    public function testWriteEmptyTargetFor410()
+    {
+        $entity = $this->prophesize(RedirectRouteInterface::class);
+        $entity->getSource()->willReturn('/source');
+        $entity->getTarget()->willReturn('');
+        $entity->getStatusCode()->willReturn(Response::HTTP_GONE);
+
+        $this->redirectRouteManager->save($entity->reveal())->shouldBeCalled();
+
+        $this->writer->write($entity->reveal());
+
+        $this->redirectRouteManager->save($entity->reveal())->shouldBeCalled();
     }
 
     public function testFinalize()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

This PR allows empty target for 410 redirect import.

#### Why?

When creating an 410 redirect in the UI the target is empty. But the import does not allow this.
