### PR TITLE
Add csv import without header

### DIFF
--- a/Import/Reader/CsvReader.php
+++ b/Import/Reader/CsvReader.php
@@ -12,6 +12,7 @@
 namespace Sulu\Bundle\RedirectBundle\Import\Reader;
 
 use SplFileObject;
+use Sulu\Bundle\RedirectBundle\Import\Converter\Converter;
 
 /**
  * Read a csv-file and stream each line as item into a callback.
@@ -29,16 +30,17 @@ class CsvReader implements ReaderInterface
         $csv->setCsvControl();
         $csv->setFlags(SplFileObject::READ_CSV);
 
-        $header = null;
+        $header = [Converter::SOURCE, Converter::TARGET, Converter::STATUS_CODE, Converter::ENABLED];
         foreach ($csv as $lineNumber => $line) {
             if (1 === count($line) && '' === trim($line[0])) {
                 continue;
             }
 
             if (0 == $lineNumber) {
-                $header = $line;
-
-                continue;
+                if (false !== array_search(Converter::SOURCE, $line)) {
+                    $header = $line;
+                    continue;
+                }
             }
 
             yield new ReaderItem($lineNumber, '"' . implode('","', $line) . '"', $this->interpret($line, $header));

--- a/Import/Reader/CsvReader.php
+++ b/Import/Reader/CsvReader.php
@@ -32,11 +32,12 @@ class CsvReader implements ReaderInterface
 
         $header = [Converter::SOURCE, Converter::TARGET, Converter::STATUS_CODE, Converter::ENABLED];
         foreach ($csv as $lineNumber => $line) {
-            if (1 === count($line) && '' === trim($line[0])) {
+            // ignore empty lines
+            if (empty(array_filter($line))) {
                 continue;
             }
 
-            if (0 == $lineNumber) {
+            if (0 === $lineNumber) {
                 if (false !== array_search(Converter::SOURCE, $line)) {
                     $header = $line;
                     continue;

--- a/Tests/Functional/Import/Reader/CsvReaderTest.php
+++ b/Tests/Functional/Import/Reader/CsvReaderTest.php
@@ -35,12 +35,12 @@ class CsvReaderTest extends \PHPUnit_Framework_TestCase
         $reader = new CsvReader();
         $fileName = __DIR__ . '/import.csv';
 
-        $i = 1;
+        $i = 0;
         foreach ($reader->read($fileName) as $item) {
+            ++$i;
+
             $this->assertEquals('/source-' . $i, $item->getData()['source']);
             $this->assertEquals('/target-' . $i, $item->getData()['target']);
-
-            ++$i;
         }
 
         $this->assertSame(4, $i);
@@ -51,12 +51,12 @@ class CsvReaderTest extends \PHPUnit_Framework_TestCase
         $reader = new CsvReader();
         $fileName = __DIR__ . '/import-without-header.csv';
 
-        $i = 1;
+        $i = 0;
         foreach ($reader->read($fileName) as $item) {
+            ++$i;
+
             $this->assertEquals('/source-' . $i, $item->getData()['source']);
             $this->assertEquals('/target-' . $i, $item->getData()['target']);
-
-            ++$i;
         }
 
         $this->assertSame(1, $i);

--- a/Tests/Functional/Import/Reader/CsvReaderTest.php
+++ b/Tests/Functional/Import/Reader/CsvReaderTest.php
@@ -42,6 +42,24 @@ class CsvReaderTest extends \PHPUnit_Framework_TestCase
 
             ++$i;
         }
+
+        $this->assertSame(4, $i);
+    }
+
+    public function testReadWithoutHeader()
+    {
+        $reader = new CsvReader();
+        $fileName = __DIR__ . '/import-without-header.csv';
+
+        $i = 1;
+        foreach ($reader->read($fileName) as $item) {
+            $this->assertEquals('/source-' . $i, $item->getData()['source']);
+            $this->assertEquals('/target-' . $i, $item->getData()['target']);
+
+            ++$i;
+        }
+
+        $this->assertSame(1, $i);
     }
 
     public function testReadDifferentRows()
@@ -64,5 +82,7 @@ class CsvReaderTest extends \PHPUnit_Framework_TestCase
 
             ++$i;
         }
+
+        $this->assertSame(3, $i);
     }
 }

--- a/Tests/Functional/Import/Reader/import-without-header.csv
+++ b/Tests/Functional/Import/Reader/import-without-header.csv
@@ -1,0 +1,1 @@
+/source-1,/target-1


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #16
| Related issues/PRs |
| License | MIT

#### What's in this PR?

Add csv import without header.

#### Why?

So the header need to be not always set in the csv and a simple source target csv can be used.

