### PR TITLE
Enable redirect routes by default

### DIFF
--- a/Resources/config/forms/redirect_route_details.xml
+++ b/Resources/config/forms/redirect_route_details.xml
@@ -58,6 +58,7 @@
             </meta>
             <params>
                 <param name="type" value="toggler"/>
+                <param name="default_value" value="true"/>
             </params>
         </property>
     </properties>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Enable redirect routes by default.

#### Why?

Also a checkbox can have 3 values (null, false, true) and if not changed it will send null.
See https://github.com/sulu/sulu-docs/pull/444/files so a default value is in all cases required.