### PR TITLE
Fix ImportCommand service definition

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -56,7 +56,7 @@
             <argument type="service" id="jms_serializer.unserialize_object_constructor"/>
         </service>
 
-        <service id="sulu_article.reindex_command" class="Sulu\Bundle\RedirectBundle\Command\ImportCommand">
+        <service id="sulu_redirect.import_command" class="Sulu\Bundle\RedirectBundle\Command\ImportCommand">
             <argument type="service" id="sulu_redirect.import"/>
             <tag name="console.command"/>
         </service>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Renames service definition of `ImportCommand` from `sulu_article.reindex_command` to `sulu_redirect.import_command`

#### Why?

Because it conflicts when both, SuluArticleBundle and SuluRedirectBundle are installed.
