### PR TITLE
Match source and sourcehost case insensitively

### DIFF
--- a/Entity/RedirectRoute.php
+++ b/Entity/RedirectRoute.php
@@ -119,7 +119,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setSource($source)
     {
-        $this->source = '/' . ltrim($source, '/');
+        $this->source = mb_strtolower('/' . ltrim($source, '/'));
 
         return $this;
     }
@@ -137,11 +137,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setSourceHost($sourceHost)
     {
-        if (empty($sourceHost)) {
-            $sourceHost = null;
-        }
-
-        $this->sourceHost = $sourceHost;
+        $this->sourceHost = empty($sourceHost) ? null : mb_strtolower($sourceHost);
 
         return $this;
     }
@@ -159,7 +155,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setTarget($target)
     {
-        $this->target = $target;
+        $this->target = mb_strtolower($target);
 
         return $this;
     }

--- a/Entity/RedirectRouteRepository.php
+++ b/Entity/RedirectRouteRepository.php
@@ -79,7 +79,7 @@ class RedirectRouteRepository extends EntityRepository implements RedirectRouteR
     {
         $queryBuilder = $this->createQueryBuilder('redirect_route')
             ->andWhere('redirect_route.source = :source')
-            ->setParameter('source', $source)
+            ->setParameter('source', mb_strtolower('/' . ltrim($source, '/')))
             ->orderBy('redirect_route.sourceHost', 'DESC')
             ->setMaxResults(1);
 
@@ -92,7 +92,7 @@ class RedirectRouteRepository extends EntityRepository implements RedirectRouteR
                 )
             );
 
-            $queryBuilder->setParameter('sourceHost', $sourceHost);
+            $queryBuilder->setParameter('sourceHost', mb_strtolower($sourceHost));
         }
 
         return $queryBuilder;

--- a/Manager/RedirectRouteManager.php
+++ b/Manager/RedirectRouteManager.php
@@ -54,14 +54,6 @@ class RedirectRouteManager implements RedirectRouteManagerInterface
             $redirectRoute->setId(Uuid::uuid4()->toString());
         }
 
-        if (
-            $otherRoute &&
-            $otherRoute->getId() !== $redirectRoute->getId() &&
-            $otherRoute->getSourceHost() === $redirectRoute->getSourceHost()
-        ) {
-            throw new RedirectRouteNotUniqueException($source, $sourceHost);
-        }
-
         // update data
         $redirectRoute->setSource($data['source']);
         $redirectRoute->setSourceHost($data['sourceHost']);
@@ -71,6 +63,14 @@ class RedirectRouteManager implements RedirectRouteManagerInterface
 
         if (410 === $redirectRoute->getStatusCode()) {
             $redirectRoute->setTarget('');
+        }
+
+        if (
+            $otherRoute &&
+            $otherRoute->getId() !== $redirectRoute->getId() &&
+            $otherRoute->getSourceHost() === $redirectRoute->getSourceHost()
+        ) {
+            throw new RedirectRouteNotUniqueException($source, $sourceHost);
         }
 
         $this->redirectRouteRepository->persist($redirectRoute);

--- a/Resources/config/router.xml
+++ b/Resources/config/router.xml
@@ -6,6 +6,7 @@
     <services>
         <service id="sulu_redirect.routing.provider" class="Sulu\Bundle\RedirectBundle\Routing\RedirectRouteProvider">
             <argument type="service" id="sulu.repository.redirect_route"/>
+            <argument type="collection" />
 
             <tag name="sulu.context" context="website"/>
         </service>

--- a/Routing/RedirectRouteProvider.php
+++ b/Routing/RedirectRouteProvider.php
@@ -28,9 +28,17 @@ class RedirectRouteProvider implements RouteProviderInterface
      */
     private $redirectRouteRepository;
 
-    public function __construct(RedirectRouteRepositoryInterface $redirectRouteRepository)
-    {
+    /**
+     * @var array
+     */
+    private $defaultOptions;
+
+    public function __construct(
+        RedirectRouteRepositoryInterface $redirectRouteRepository,
+        array $defaultOptions = []
+    ) {
         $this->redirectRouteRepository = $redirectRouteRepository;
+        $this->defaultOptions = $defaultOptions;
     }
 
     /**
@@ -53,7 +61,9 @@ class RedirectRouteProvider implements RouteProviderInterface
             [
                 '_controller' => 'sulu_redirect.controller.redirect:redirect',
                 'redirectRoute' => $redirectRoute,
-            ]
+            ],
+            [],
+            $this->defaultOptions
         );
         $routeCollection->add(sprintf('sulu_redirect.%s', $redirectRoute->getId()), $route);
 

--- a/Routing/RedirectRouteProvider.php
+++ b/Routing/RedirectRouteProvider.php
@@ -47,7 +47,7 @@ class RedirectRouteProvider implements RouteProviderInterface
     public function getRouteCollectionForRequest(Request $request)
     {
         // server encodes the url and symfony does not encode it
-        // symfony decodes this data here https://github.com/symfony/symfony/blob/3.3/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L91
+        // symfony decodes this data here https://github.com/symfony/symfony/blob/v5.2.3/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L88
         $pathInfo = rawurldecode($request->getPathInfo());
         $host = $request->getHost();
 

--- a/Routing/RedirectRouteProvider.php
+++ b/Routing/RedirectRouteProvider.php
@@ -49,7 +49,7 @@ class RedirectRouteProvider implements RouteProviderInterface
         }
 
         $route = new Route(
-            $redirectRoute->getSource(),
+            $pathInfo,
             [
                 '_controller' => 'sulu_redirect.controller.redirect:redirect',
                 'redirectRoute' => $redirectRoute,

--- a/SuluRedirectBundle.php
+++ b/SuluRedirectBundle.php
@@ -11,9 +11,9 @@
 
 namespace Sulu\Bundle\RedirectBundle;
 
-use Sulu\Component\Route\RouteDefaultOptionsCompilerPass;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\RedirectBundle\Entity\RedirectRoute;
+use Sulu\Component\Route\RouteDefaultOptionsCompilerPass;
 use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;

--- a/SuluRedirectBundle.php
+++ b/SuluRedirectBundle.php
@@ -11,6 +11,7 @@
 
 namespace Sulu\Bundle\RedirectBundle;
 
+use Sulu\Component\Route\RouteDefaultOptionsCompilerPass;
 use Sulu\Bundle\PersistenceBundle\PersistenceBundleTrait;
 use Sulu\Bundle\RedirectBundle\Entity\RedirectRoute;
 use Sulu\Component\Symfony\CompilerPass\TaggedServiceCollectorCompilerPass;
@@ -40,6 +41,10 @@ class SuluRedirectBundle extends Bundle
                 'sulu_redirect.import.aggregate_converter',
                 'sulu_redirect.import.converter'
             )
+        );
+
+        $container->addCompilerPass(
+            new RouteDefaultOptionsCompilerPass('sulu_redirect.routing.provider', 1)
         );
 
         $this->buildPersistence(

--- a/Tests/Application/Kernel.php
+++ b/Tests/Application/Kernel.php
@@ -35,7 +35,7 @@ class Kernel extends SuluTestKernel
     {
         parent::registerContainerConfiguration($loader);
 
-        $loader->load(__DIR__ . '/config/config.yml');
+        $loader->load(__DIR__ . '/config/config_' . $this->getContext() . '.yml');
     }
 
     protected function getKernelParameters()

--- a/Tests/Application/config/config.yml
+++ b/Tests/Application/config/config.yml
@@ -1,4 +1,10 @@
-# Doctrine Configuration
+framework:
+    router:
+        utf8: true
+
+swiftmailer:
+    disable_delivery:  true
+
 doctrine:
     orm:
         mappings:

--- a/Tests/Application/config/config_admin.yml
+++ b/Tests/Application/config/config_admin.yml
@@ -1,0 +1,5 @@
+imports:
+    - config.yml
+
+framework:
+    router: { resource: "%kernel.project_dir%/config/routing_admin.yml" }

--- a/Tests/Application/config/config_website.yml
+++ b/Tests/Application/config/config_website.yml
@@ -1,0 +1,5 @@
+imports:
+    - config.yml
+
+framework:
+    router: { resource: '%kernel.project_dir%/config/routing_website.yml' }

--- a/Tests/Application/config/routing_admin.yml
+++ b/Tests/Application/config/routing_admin.yml
@@ -1,0 +1,8 @@
+sulu_redirect_api:
+    type: rest
+    resource: "@SuluRedirectBundle/Resources/config/routing_api.yml"
+    prefix: /admin/api
+
+sulu_redirect:
+    resource: "@SuluRedirectBundle/Resources/config/routing.yml"
+    prefix: /admin/redirects

--- a/Tests/Application/config/templates/pages/overview.xml
+++ b/Tests/Application/config/templates/pages/overview.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" ?>
+<template xmlns="http://schemas.sulu.io/template/template"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://schemas.sulu.io/template/template http://schemas.sulu.io/template/template-1.0.xsd">
+
+    <key>overview</key>
+
+    <view>base</view>
+    <controller>Sulu\Bundle\WebsiteBundle\Controller\DefaultController::indexAction</controller>
+    <cacheLifetime>604800</cacheLifetime>
+
+    <meta>
+        <title lang="en">Overview</title>
+        <title lang="de">Übersicht</title>
+    </meta>
+
+    <properties>
+        <property name="title" type="text_line" mandatory="true">
+            <meta>
+                <title lang="en">Title</title>
+                <title lang="de">Titel</title>
+            </meta>
+            <params>
+                <param name="headline" value="true"/>
+            </params>
+
+            <tag name="sulu.rlp.part"/>
+        </property>
+
+        <property name="url" type="resource_locator" mandatory="true">
+            <meta>
+                <title lang="en">Resourcelocator</title>
+                <title lang="de">Adresse</title>
+            </meta>
+
+            <tag name="sulu.rlp"/>
+        </property>
+
+        <property name="article" type="text_editor">
+            <meta>
+                <title lang="en">Article</title>
+                <title lang="de">Artikel</title>
+            </meta>
+        </property>
+    </properties>
+</template>

--- a/Tests/Application/config/webspaces/sulu.io.xml
+++ b/Tests/Application/config/webspaces/sulu.io.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<webspace xmlns="http://schemas.sulu.io/webspace/webspace"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://schemas.sulu.io/webspace/webspace http://schemas.sulu.io/webspace/webspace-1.1.xsd">
+
+    <name>Sulu CMF</name>
+    <key>sulu-io</key>
+
+    <security>
+        <system>Website</system>
+    </security>
+
+    <localizations>
+        <localization language="de" default="true"/>
+    </localizations>
+
+    <theme>default</theme>
+
+    <default-templates>
+        <default-template type="homepage">overview</default-template>
+        <default-template type="page">overview</default-template>
+    </default-templates>
+
+    <navigation>
+        <contexts>
+            <context key="main">
+                <meta>
+                    <title lang="en">Mainnavigation</title>
+                </meta>
+            </context>
+        </contexts>
+    </navigation>
+
+    <portals>
+        <portal>
+            <name>Sulu CMF AT</name>
+            <key>sulucmf_at</key>
+
+            <environments>
+                <environment type="prod">
+                    <urls>
+                        <url language="de">{host}</url>
+                    </urls>
+                </environment>
+                <environment type="dev">
+                    <urls>
+                        <url language="de">{host}</url>
+                    </urls>
+                </environment>
+                <environment type="test">
+                    <urls>
+                        <url language="de">{host}</url>
+                    </urls>
+                </environment>
+            </environments>
+        </portal>
+    </portals>
+</webspace>

--- a/Tests/Functional/Controller/RedirectRouteControllerTest.php
+++ b/Tests/Functional/Controller/RedirectRouteControllerTest.php
@@ -73,7 +73,25 @@ class RedirectRouteControllerTest extends SuluTestCase
         $response = $this->post($this->defaultData);
         $this->assertHttpStatusCode(200, $response);
 
-        $response = $this->post($this->defaultData);
+        $response = $this->post(array_merge($this->defaultData, ['source' => '/test1']));
+        $this->assertHttpStatusCode(409, $response);
+
+        $response = $this->post(array_merge($this->defaultData, ['source' => 'test1']));
+        $this->assertHttpStatusCode(409, $response);
+
+        $response = $this->post(array_merge($this->defaultData, ['source' => '/TEST1']));
+        $this->assertHttpStatusCode(409, $response);
+
+        $response = $this->post(array_merge($this->defaultData, ['source' => 'TEST1']));
+        $this->assertHttpStatusCode(409, $response);
+    }
+
+    public function testPostWithSourceHostAlreadyExists()
+    {
+        $response = $this->post(array_merge($this->defaultData, ['source' => '/test1', 'sourceHost' => 'sulu.io']));
+        $this->assertHttpStatusCode(200, $response);
+
+        $response = $this->post(array_merge($this->defaultData, ['source' => '/test1', 'sourceHost' => 'sulu.io']));
         $this->assertHttpStatusCode(409, $response);
     }
 
@@ -105,9 +123,22 @@ class RedirectRouteControllerTest extends SuluTestCase
     public function testPutAlreadyExists()
     {
         $response = $this->post($this->defaultData);
+        $data = json_decode($response->getContent(), true);
         $this->assertHttpStatusCode(200, $response);
 
-        $response = $this->post($this->defaultData);
+        $response = $this->post(array_merge($this->defaultData, ['source' => '/test2']));
+        $this->assertHttpStatusCode(200, $response);
+
+        $response = $this->put($data['id'], array_merge($this->defaultData, ['source' => '/test2']));
+        $this->assertHttpStatusCode(409, $response);
+
+        $response = $this->put($data['id'], array_merge($this->defaultData, ['source' => 'test2']));
+        $this->assertHttpStatusCode(409, $response);
+
+        $response = $this->put($data['id'], array_merge($this->defaultData, ['source' => '/TEST2']));
+        $this->assertHttpStatusCode(409, $response);
+
+        $response = $this->put($data['id'], array_merge($this->defaultData, ['source' => 'TEST2']));
         $this->assertHttpStatusCode(409, $response);
     }
 

--- a/Tests/Functional/Controller/RedirectRouteControllerTest.php
+++ b/Tests/Functional/Controller/RedirectRouteControllerTest.php
@@ -16,7 +16,7 @@ use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 
 class RedirectRouteControllerTest extends SuluTestCase
 {
-    const BASE_URL = '/api/redirect-routes';
+    const BASE_URL = '/admin/api/redirect-routes';
 
     /**
      * @var array

--- a/Tests/Functional/Routing/RedirectRouteProviderTest.php
+++ b/Tests/Functional/Routing/RedirectRouteProviderTest.php
@@ -1,5 +1,13 @@
 <?php
 
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
 
 namespace Sulu\Bundle\RedirectBundle\Tests\Functional\Routing;
 
@@ -57,26 +65,26 @@ class RedirectRouteProviderTest extends WebsiteTestCase
         }
     }
 
-    public function routeDataProvider()
+    public function routeDataProvider(): \Generator
     {
         yield [
             '/test-301',
             '/test-301',
             301,
-            '/test2'
+            '/test2',
         ];
 
         yield [
             '/test-302',
             '/test-302',
             302,
-            '/test2'
+            '/test2',
         ];
 
         yield [
             '/test-401',
             '/test-401',
-            410
+            410,
         ];
 
         yield [
@@ -84,14 +92,14 @@ class RedirectRouteProviderTest extends WebsiteTestCase
             '/test-domain-redirect',
             301,
             '/',
-            'with-domain.com'
+            'with-domain.com',
         ];
 
         yield [
             '/test-emoticon-%F0%9F%8E%89', // browsers will encode the url and be provided this way to symfony getPathInfo
             '/test-emoticon-🎉',
             301,
-            '/'
+            '/',
         ];
     }
 }

--- a/Tests/Functional/Routing/RedirectRouteProviderTest.php
+++ b/Tests/Functional/Routing/RedirectRouteProviderTest.php
@@ -1,0 +1,97 @@
+<?php
+
+
+namespace Sulu\Bundle\RedirectBundle\Tests\Functional\Routing;
+
+use Ramsey\Uuid\Uuid;
+use Sulu\Bundle\RedirectBundle\Entity\RedirectRoute;
+use Sulu\Bundle\TestBundle\Testing\WebsiteTestCase;
+use Symfony\Bundle\FrameworkBundle\KernelBrowser;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+class RedirectRouteProviderTest extends WebsiteTestCase
+{
+    /**
+     * @var KernelBrowser
+     */
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->client = static::createWebsiteClient();
+        static::purgeDatabase();
+    }
+
+    /**
+     * @dataProvider routeDataProvider
+     */
+    public function testRoute(
+        string $requestUrl,
+        string $source,
+        int $statusCode,
+        ?string $target = null,
+        ?string $sourceHost = null
+    ) {
+        // setup models
+        $redirectRoute = new RedirectRoute();
+        $redirectRoute->setId(Uuid::uuid4()->toString());
+        $redirectRoute->setSource($source);
+        $redirectRoute->setSourceHost($sourceHost);
+        $redirectRoute->setStatusCode($statusCode);
+        $redirectRoute->setTarget($target);
+        $redirectRoute->setEnabled(true);
+
+        // save models
+        static::getEntityManager()->persist($redirectRoute);
+        static::getEntityManager()->flush();
+        static::getEntityManager()->clear();
+
+        $this->client->request('GET', $requestUrl);
+
+        $response = $this->client->getResponse();
+        $this->assertHttpStatusCode($statusCode, $response);
+
+        if ($target) {
+            $this->assertInstanceOf(RedirectResponse::class, $response);
+            $this->assertSame($target, $response->getTargetUrl());
+        }
+    }
+
+    public function routeDataProvider()
+    {
+        yield [
+            '/test-301',
+            '/test-301',
+            301,
+            '/test2'
+        ];
+
+        yield [
+            '/test-302',
+            '/test-302',
+            302,
+            '/test2'
+        ];
+
+        yield [
+            '/test-401',
+            '/test-401',
+            410
+        ];
+
+        yield [
+            'http://with-domain.com/test-domain-redirect',
+            '/test-domain-redirect',
+            301,
+            '/',
+            'with-domain.com'
+        ];
+
+        yield [
+            '/test-emoticon-%F0%9F%8E%89', // browsers will encode the url and be provided this way to symfony getPathInfo
+            '/test-emoticon-🎉',
+            301,
+            '/'
+        ];
+    }
+}

--- a/Tests/Unit/Entity/RedirectRouteTest.php
+++ b/Tests/Unit/Entity/RedirectRouteTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of Sulu.
+ *
+ * (c) Sulu GmbH
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Sulu\Bundle\RedirectBundle\Tests\Unit\Import\Converter;
+
+use PHPUnit\Framework\TestCase;
+use Sulu\Bundle\RedirectBundle\Entity\RedirectRoute;
+
+class RedirectRouteTest extends TestCase
+{
+    public function testId()
+    {
+        $route = new RedirectRoute();
+
+        $this->assertSame($route, $route->setId('123-123-123-123'));
+        $this->assertSame('123-123-123-123', $route->getId());
+    }
+
+    public function testEnabled()
+    {
+        $route = new RedirectRoute();
+
+        $this->assertSame(true, $route->isEnabled());
+        $this->assertSame($route, $route->setEnabled(false));
+        $this->assertSame(false, $route->isEnabled());
+    }
+
+    public function testStatusCode()
+    {
+        $route = new RedirectRoute();
+
+        $this->assertSame(301, $route->getStatusCode());
+        $this->assertSame($route, $route->setStatusCode(410));
+        $this->assertSame(410, $route->getStatusCode());
+    }
+
+    public function testSource()
+    {
+        $route = new RedirectRoute();
+
+        $this->assertSame($route, $route->setSource('/redirect-source'));
+        $this->assertSame('/redirect-source', $route->getSource());
+
+        $this->assertSame($route, $route->setSource('missing-leading-slash'));
+        $this->assertSame('/missing-leading-slash', $route->getSource());
+
+        $this->assertSame($route, $route->setSource('/UPPERCASE-SOURCE'));
+        $this->assertSame('/uppercase-source', $route->getSource());
+    }
+
+    public function testSourceHost()
+    {
+        $route = new RedirectRoute();
+
+        $this->assertSame($route, $route->setSourceHost(null));
+        $this->assertSame(null, $route->getSourceHost());
+
+        $this->assertSame($route, $route->setSourceHost('sulu.io'));
+        $this->assertSame('sulu.io', $route->getSourceHost());
+
+        $this->assertSame($route, $route->setSourceHost('SULU.IO'));
+        $this->assertSame('sulu.io', $route->getSourceHost());
+    }
+
+    public function testTarget()
+    {
+        $route = new RedirectRoute();
+
+        $this->assertSame($route, $route->setTarget('target-url'));
+        $this->assertSame('target-url', $route->getTarget());
+
+        $this->assertSame($route, $route->setTarget('UPPERCASE-TARGET'));
+        $this->assertSame('uppercase-target', $route->getTarget());
+    }
+}

--- a/Tests/Unit/Manager/RedirectRouteManagerTest.php
+++ b/Tests/Unit/Manager/RedirectRouteManagerTest.php
@@ -84,6 +84,13 @@ class RedirectRouteManagerTest extends TestCase
 
         $redirectRoute = $this->prophesize(RedirectRouteInterface::class);
         $redirectRoute->setId(Argument::any())->shouldBeCalled();
+        $redirectRoute->setSource('/test')->shouldBeCalled();
+        $redirectRoute->setSourceHost('www.example.com')->shouldBeCalled();
+        $redirectRoute->setEnabled(true)->shouldBeCalled();
+        $redirectRoute->setTarget('/test2')->shouldBeCalled();
+        $redirectRoute->setStatusCode(301)->shouldBeCalled();
+        $redirectRoute->getStatusCode()->willReturn(301);
+
         $redirectRoute->getId()->willReturn('234-234-234');
         $redirectRoute->getSourceHost()->willReturn('www.example.com');
 

--- a/Tests/Unit/Routing/RedirectRouteProviderTest.php
+++ b/Tests/Unit/Routing/RedirectRouteProviderTest.php
@@ -39,7 +39,7 @@ class RedirectRouteProviderTest extends TestCase
     {
         $this->repository = $this->prophesize(RedirectRouteRepositoryInterface::class);
 
-        $this->routeProvider = new RedirectRouteProvider($this->repository->reveal());
+        $this->routeProvider = new RedirectRouteProvider($this->repository->reveal(), ['utf8' => true]);
 
         $this->request = $this->prophesize(Request::class);
     }
@@ -69,6 +69,9 @@ class RedirectRouteProviderTest extends TestCase
             ],
             $result->get('sulu_redirect.' . $uuid)->getDefaults()
         );
+
+        $this->assertArrayHasKey('utf8', $result->get('sulu_redirect.' . $uuid)->getOptions());
+        $this->assertSame(true, $result->get('sulu_redirect.' . $uuid)->getOptions()['utf8']);
     }
 
     public function testGetRouteCollectionForRequestEncodedPathInfo()


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

This PR adjusts the code to match the `source` and `sourceHost` of a redirect in a case-insensitive manner.

Assuming a redirect with `source: "redirect-url", sourceHost: "www.test.com"`:

Behaviour before: matches only `www.test.com/redirect-url`
Behaviour after: matches `www.test.com/redirect-url`, `www.test.com/redirect-URL`, `www.test.com/REDIRECT-url`, ...

#### Why?

Because [MySQL is case insensitive by default](https://stackoverflow.com/questions/12129571/doctrine2-case-sensitive-query). This means it is not possible to create two redirects that use the same characters (eg. one redirect for `redirect-url` and one redirect for `redirect-URL`). 

Because of this, without this change, it is not possible to redirect both urls (`www.test.com/redirect-url` and `www.test.com/redirect-URL`) at all.