### PR TITLE
Remove strtolower transform from RedirectRoute::setTarget

### DIFF
--- a/Entity/RedirectRoute.php
+++ b/Entity/RedirectRoute.php
@@ -119,7 +119,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setSource($source)
     {
-        $this->source = '/' . ltrim($source, '/');
+        $this->source = mb_strtolower('/' . ltrim($source, '/'));
 
         return $this;
     }
@@ -137,7 +137,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setSourceHost($sourceHost)
     {
-        $this->sourceHost = empty($sourceHost) ? null : $sourceHost;
+        $this->sourceHost = empty($sourceHost) ? null : mb_strtolower($sourceHost);
 
         return $this;
     }

--- a/Entity/RedirectRoute.php
+++ b/Entity/RedirectRoute.php
@@ -119,7 +119,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setSource($source)
     {
-        $this->source = mb_strtolower('/' . ltrim($source, '/'));
+        $this->source = '/' . ltrim($source, '/');
 
         return $this;
     }
@@ -137,7 +137,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setSourceHost($sourceHost)
     {
-        $this->sourceHost = empty($sourceHost) ? null : mb_strtolower($sourceHost);
+        $this->sourceHost = empty($sourceHost) ? null : $sourceHost;
 
         return $this;
     }
@@ -155,7 +155,7 @@ class RedirectRoute implements RedirectRouteInterface, AuditableInterface
      */
     public function setTarget($target)
     {
-        $this->target = mb_strtolower($target);
+        $this->target = $target;
 
         return $this;
     }

--- a/Import/Writer/DuplicatedSourceException.php
+++ b/Import/Writer/DuplicatedSourceException.php
@@ -30,9 +30,7 @@ class DuplicatedSourceException extends WriterException implements \JsonSerializ
         $this->entity = $entity;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/Import/Writer/TargetIsEmptyException.php
+++ b/Import/Writer/TargetIsEmptyException.php
@@ -30,9 +30,7 @@ class TargetIsEmptyException extends WriterException implements \JsonSerializabl
         $this->entity = $entity;
     }
 
-    /**
-     * {@inheritdoc}
-     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/Tests/Functional/Routing/RedirectRouteProviderTest.php
+++ b/Tests/Functional/Routing/RedirectRouteProviderTest.php
@@ -37,7 +37,7 @@ class RedirectRouteProviderTest extends WebsiteTestCase
         string $requestUrl,
         string $source,
         int $statusCode,
-        ?string $target = null,
+        string $target = '',
         ?string $sourceHost = null
     ) {
         // setup models

--- a/Tests/Unit/Entity/RedirectRouteTest.php
+++ b/Tests/Unit/Entity/RedirectRouteTest.php
@@ -78,6 +78,6 @@ class RedirectRouteTest extends TestCase
         $this->assertSame('target-url', $route->getTarget());
 
         $this->assertSame($route, $route->setTarget('UPPERCASE-TARGET'));
-        $this->assertSame('uppercase-target', $route->getTarget());
+        $this->assertSame('UPPERCASE-TARGET', $route->getTarget());
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -316,11 +316,6 @@ parameters:
 			path: Tests/Functional/Routing/RedirectRouteProviderTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$target of method Sulu\\\\Bundle\\\\RedirectBundle\\\\Entity\\\\RedirectRoute\\:\\:setTarget\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: Tests/Functional/Routing/RedirectRouteProviderTest.php
-
-		-
 			message: "#^Call to an undefined method Sulu\\\\Bundle\\\\RedirectBundle\\\\Model\\\\RedirectRouteInterface\\:\\:reveal\\(\\)\\.$#"
 			count: 4
 			path: Tests/Unit/Controller/RedirectControllerTest.php


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT

#### What's in this PR?

This PR removes the `mb_strtolower` transform from `RedirectRoute::setSource()`, `RedirectRoute::setSourceHost()` and `RedirectRoute::setTarget()`.

#### Why?

 I'm not sure if there was a real reason, that the `mb_strtolower` has been used for `source` and `sourceHost`, but at least for `target` it needs to be removed, because some websites return different responses for `https://example.com/en_US` and `https://example.com/en_us` e.g.
