### PR TITLE
Add format-suffix handling

### DIFF
--- a/Controller/WebsiteRedirectController.php
+++ b/Controller/WebsiteRedirectController.php
@@ -34,8 +34,12 @@ class WebsiteRedirectController
 
         $queryString = http_build_query($request->query->all());
 
+        $requestFormat = $request->getRequestFormat(null);
+        $formatSuffix = $requestFormat ? ('.' . $requestFormat) : '';
+
         $url = [
             $redirectRoute->getTarget(),
+            $formatSuffix,
             false === strpos($redirectRoute->getTarget(), '?') ? '?' : '&',
             $queryString,
         ];

--- a/Routing/RedirectRouteProvider.php
+++ b/Routing/RedirectRouteProvider.php
@@ -49,10 +49,11 @@ class RedirectRouteProvider implements RouteProviderInterface
         // server encodes the url and symfony does not encode it
         // symfony decodes this data here https://github.com/symfony/symfony/blob/v5.2.3/src/Symfony/Component/Routing/Matcher/UrlMatcher.php#L88
         $pathInfo = rawurldecode($request->getPathInfo());
+        $path = \str_replace('.' . $request->getRequestFormat(), '', $pathInfo);
         $host = $request->getHost();
 
         $routeCollection = new RouteCollection();
-        if (!$redirectRoute = $this->redirectRouteRepository->findEnabledBySource($pathInfo, $host)) {
+        if (!$redirectRoute = $this->redirectRouteRepository->findEnabledBySource($path, $host)) {
             return $routeCollection;
         }
 

--- a/Tests/Functional/Routing/RedirectRouteProviderTest.php
+++ b/Tests/Functional/Routing/RedirectRouteProviderTest.php
@@ -38,6 +38,7 @@ class RedirectRouteProviderTest extends WebsiteTestCase
         string $source,
         int $statusCode,
         string $target = '',
+        string $targetUrl = '',
         ?string $sourceHost = null
     ) {
         // setup models
@@ -61,7 +62,7 @@ class RedirectRouteProviderTest extends WebsiteTestCase
 
         if ($target) {
             $this->assertInstanceOf(RedirectResponse::class, $response);
-            $this->assertSame($target, $response->getTargetUrl());
+            $this->assertSame($targetUrl, $response->getTargetUrl());
         }
     }
 
@@ -72,12 +73,14 @@ class RedirectRouteProviderTest extends WebsiteTestCase
             '/test-301',
             301,
             '/test2',
+            '/test2',
         ];
 
         yield [
             '/test-302',
             '/test-302',
             302,
+            '/test2',
             '/test2',
         ];
 
@@ -92,6 +95,7 @@ class RedirectRouteProviderTest extends WebsiteTestCase
             '/test-domain-redirect',
             301,
             '/',
+            '/',
             'with-domain.com',
         ];
 
@@ -100,6 +104,15 @@ class RedirectRouteProviderTest extends WebsiteTestCase
             '/test-emoticon-🎉',
             301,
             '/',
+            '/',
+        ];
+
+        yield [
+            '/source.json', // browsers will encode the url and be provided this way to symfony getPathInfo
+            '/source',
+            301,
+            '/target',
+            '/target.json',
         ];
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT

#### What's in this PR?

The PR fixes the handling of format-suffix.

#### Why?

When calling the redirect-route the format should be kept. E.g.: /source.json => /target.json or /source => /target

#### To Do

- [x] Tests
