### PR TITLE
Add explicit int cast to redirect controller

### DIFF
--- a/Controller/RedirectRouteController.php
+++ b/Controller/RedirectRouteController.php
@@ -121,8 +121,8 @@ class RedirectRouteController extends AbstractRestController implements ClassRes
             $results,
             self::RESULT_KEY,
             $listBuilder->getCurrentPage(),
-            $listBuilder->getLimit(),
-            $listBuilder->count(),
+            (int) $listBuilder->getLimit(),
+            (int) $listBuilder->count(),
         );
 
         return $this->handleView($this->view($list));

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,12 +67,6 @@ parameters:
 			path: Controller/RedirectRouteController.php
 
 		-
-			message: '#^Parameter \#4 \$limit of class Sulu\\Component\\Rest\\ListBuilder\\PaginatedRepresentation constructor expects int, int\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: Controller/RedirectRouteController.php
-
-		-
 			message: '#^Method Sulu\\Bundle\\RedirectBundle\\Controller\\RedirectRouteImportController\:\:getLocale\(\) should return string\|null but returns mixed\.$#'
 			identifier: return.type
 			count: 1


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | https://github.com/sulu/sulu/issues/8641
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?
Explicitly casting limit and count to int.

#### Why?
They might be null, but the `PaginatedRepresentation` can't handle that.