### PR TITLE
Remove not longer required jackalope package and apply some codex fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 # tests
 Tests/Application/var/
 Tests/Application/*.local
+.phpunit.cache/
 
 # php-cs-fixer
 .php_cs.cache

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
         <img src="https://img.shields.io/github/actions/workflow/status/sulu/SuluRedirectBundle/test-application.yaml" alt="Test workflow status">
     </a>
     <a href="https://github.com/sulu/sulu/releases" target="_blank">
-        <img src="https://img.shields.io/badge/sulu%20compatibility-%3E=2.0-52b6ca.svg" alt="Sulu compatibility">
+        <img src="https://img.shields.io/badge/sulu%20compatibility-%5E3.0-52b6ca.svg" alt="Sulu compatibility">
     </a>
 </p>
 <br/>
@@ -31,7 +31,7 @@ and allows content managers to manage redirects without any knowledge of web ser
 </p>
 <br/>
 
-The SuluRedirectBundle is compatible with Sulu **starting from version 2.0**. Have a look at the `require` section in
+The SuluRedirectBundle is compatible with Sulu **starting from version 3.0**. Have a look at the `require` section in
 the [composer.json](composer.json) to find an
 **up-to-date list of the requirements** of the bundle.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and allows content managers to manage redirects without any knowledge of web ser
 </p>
 <br/>
 
-The SuluRedirectBundle is compatible with Sulu **starting from version 3.0**. Have a look at the `require` section in
+The SuluRedirectBundle is compatible with Sulu **starting from version 2.0**. Have a look at the `require` section in
 the [composer.json](composer.json) to find an
 **up-to-date list of the requirements** of the bundle.
 

--- a/Resources/config/lists/redirect_routes.xml
+++ b/Resources/config/lists/redirect_routes.xml
@@ -39,11 +39,11 @@
                 name="enabled"
                 searchability="yes"
                 visibility="always"
-                type="bool"
                 translation="sulu_redirect.enabled"
         >
             <field-name>enabled</field-name>
             <entity-name>%sulu.model.redirect_route.class%</entity-name>
+            <transformer type="bool"/>
         </property>
 
         <property
@@ -101,16 +101,6 @@
             </field>
         </concatenation-property>
 
-        <property
-            name="changed"
-            visibility="no"
-            type="datetime"
-            translation="sulu_admin.changed"
-        >
-            <field-name>changed</field-name>
-            <entity-name>%sulu.model.tag.class%</entity-name>
-        </property>
-
         <concatenation-property name="creator" translation="sulu_admin.creator" visibility="no">
             <field>
                 <field-name>firstName</field-name>
@@ -130,20 +120,20 @@
             name="created"
             visibility="yes"
             translation="sulu_admin.created"
-            type="datetime"
         >
             <field-name>created</field-name>
             <entity-name>%sulu.model.redirect_route.class%</entity-name>
+            <transformer type="datetime"/>
         </property>
 
         <property
                 name="changed"
                 visibility="yes"
                 translation="sulu_admin.changed"
-                type="datetime"
         >
             <field-name>changed</field-name>
             <entity-name>%sulu.model.redirect_route.class%</entity-name>
+            <transformer type="datetime"/>
         </property>
     </properties>
 </list>

--- a/Resources/config/routing.yaml
+++ b/Resources/config/routing.yaml
@@ -1,5 +1,0 @@
-sulu_redirect.import:
-    path: /import
-    controller: sulu_redirect.controller.import::postAction
-    options:
-        expose: true

--- a/Resources/config/routing_api.yaml
+++ b/Resources/config/routing_api.yaml
@@ -67,3 +67,13 @@ sulu_redirect.post_redirect-route_trigger:
         _format: json|csv
     options:
         expose: true
+
+sulu_redirect.import:
+    path: /redirect-routes/import.{_format}
+    controller: 'sulu_redirect.controller.import::postAction'
+    methods: POST
+    format: json
+    requirements:
+        _format: json|csv
+    options:
+        expose: true

--- a/Resources/config/routing_api.yaml
+++ b/Resources/config/routing_api.yaml
@@ -1,48 +1,69 @@
 sulu_redirect.get_redirect-routes:
     path: '/redirect-routes.{_format}'
-    options: { expose: true }
-    methods: GET
     controller: 'sulu_redirect.redirect_route_controller::cgetAction'
+    methods: GET
     format: json
-    requirements: { _format: json|csv }
+    requirements:
+        _format: json|csv
+    options:
+        expose: true
+
 sulu_redirect.post_redirect-route:
     path: '/redirect-routes.{_format}'
-    options: { expose: true }
-    methods: POST
     controller: 'sulu_redirect.redirect_route_controller::postAction'
+    methods: POST
     format: json
-    requirements: { _format: json|csv }
+    requirements:
+        _format: json|csv
+    options:
+        expose: true
+
 sulu_redirect.get_redirect-route:
     path: '/redirect-routes/{id}.{_format}'
-    options: { expose: true }
-    methods: GET
     controller: 'sulu_redirect.redirect_route_controller::getAction'
+    methods: GET
     format: json
-    requirements: { _format: json|csv }
+    requirements:
+        _format: json|csv
+    options:
+        expose: true
+
 sulu_redirect.put_redirect-route:
     path: '/redirect-routes/{id}.{_format}'
-    options: { expose: true }
-    methods: PUT
     controller: 'sulu_redirect.redirect_route_controller::putAction'
+    methods: PUT
     format: json
-    requirements: { _format: json|csv }
+    requirements:
+        _format: json|csv
+    options:
+        expose: true
+
 sulu_redirect.delete_redirect-route:
     path: '/redirect-routes/{id}.{_format}'
-    options: { expose: true }
-    methods: DELETE
     controller: 'sulu_redirect.redirect_route_controller::deleteAction'
+    methods: DELETE
     format: json
-    requirements: { _format: json|csv }
+    requirements:
+        _format: json|csv
+    options:
+        expose: true
+
 sulu_redirect.delete_redirect-routes:
     path: '/redirect-routes.{_format}'
-    options: { expose: true }
-    methods: DELETE
     controller: 'sulu_redirect.redirect_route_controller::cdeleteAction'
+    methods: DELETE
     format: json
-    requirements: { _format: json|csv }
+    requirements:
+        _format: json|csv
+    options:
+        expose: true
+
 sulu_redirect.post_redirect-route_trigger:
     path: '/redirect-routes/{id}.{_format}'
-    methods: POST
     controller: 'sulu_redirect.redirect_route_controller::postTriggerAction'
+    methods: POST
     format: json
-    requirements: { _format: json|csv }
+    requirements:
+        _format: json|csv
+    options:
+        expose: true

--- a/Tests/Application/config/routing_admin.yml
+++ b/Tests/Application/config/routing_admin.yml
@@ -1,7 +1,3 @@
 sulu_redirect_api:
     resource: "@SuluRedirectBundle/Resources/config/routing_api.yaml"
     prefix: /admin/api
-
-sulu_redirect:
-    resource: "@SuluRedirectBundle/Resources/config/routing.yaml"
-    prefix: /admin/redirects

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -34,9 +34,11 @@ composer require "handcraftedinthealps/rest-routing-bundle"
 
 This also includes the old routing files:
 ```
-/Resources/config/routing_api.yml -> /Resources/config/routing_api.yaml
+/Resources/config/routing_api.yml -> can be removed
 /Resources/config/routing.yml -> /Resources/config/routing.yaml
 ```
+
+The route `/admin/redirects/import` named `sulu_redirect.import` was moved to `/admin/api/redirect-routes/import` to only have a single routing file now for the bundle.
 
 ## 2.2.0
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2 || ^8.3 || ^8.4 || ^8.5",
-        "sulu/sulu": "^3.0 || ^3.0@alpha || ^3.0@dev",
+        "sulu/sulu": "^3.0 || ^3.0@dev",
         "symfony/uid": "^6.4 || ^7.1",
         "symfony/dependency-injection": "^6.4 || ^7.1",
         "symfony/config": "^6.4 || ^7.1",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.5 || ^2.0",
-        "jackalope/jackalope-doctrine-dbal": "^1.3.4 || ^2.0",
         "jangregor/phpstan-prophecy": "^2.0",
         "phpstan/phpstan": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="Tests/test-bootstrap.php">
+<phpunit colors="true" bootstrap="Tests/test-bootstrap.php" cacheDirectory=".phpunit.cache">
     <testsuites>
         <testsuite name="Sulu Redirect Bundle">
             <directory>./Tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory>.</directory>
-            <exclude>
-                <directory>Resources/</directory>
-                <directory>Tests/</directory>
-                <directory>vendor/</directory>
-            </exclude>
-        </whitelist>
-    </filter>
-
     <php>
         <env name="APP_ENV" value="test"/>
         <env name="KERNEL_CLASS" value="Sulu\Bundle\RedirectBundle\Tests\Application\Kernel"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
+
+    <source>
+        <include>
+            <directory>.</directory>
+        </include>
+        <exclude>
+            <directory>Resources/</directory>
+            <directory>Tests/</directory>
+            <directory>vendor/</directory>
+        </exclude>
+    </source>
 </phpunit>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | yes |
| Deprecations? | yes |
| Fixed tickets | - |
| Related issues/PRs | - |
| License | MIT |

#### What's in this PR?

Manual changes:
- remove the no longer required `jackalope/jackalope-doctrine-dbal` dev dependency
- normalize the admin routing setup into a single routing file
- move the import endpoint `sulu_redirect.import` from `/admin/redirects/import` to `/admin/api/redirect-routes/import`
- update the upgrade notes for the routing change
- drop the `@alpha` allowance from the Sulu 3 requirement and keep `^3.0 || ^3.0@dev`

Codex changes:
- replace deprecated list property `type` attributes with `<transformer type="..."/>` in the redirect list metadata
- remove the duplicate hidden `changed` list field that still referenced `%sulu.model.tag.class%`
- migrate `phpunit.xml.dist` to the current PHPUnit schema and add `.phpunit.cache/` to `.gitignore`
- update the README Sulu 3 compatibility badge

#### Why?

Prepare the bundle for a stable Sulu 3 release by removing an unused dependency, simplifying the routing setup, and cleaning up remaining deprecations and tooling noise.